### PR TITLE
Refine 'Just now' display in ActivityTimeline

### DIFF
--- a/src/components/ActivityTimeline.tsx
+++ b/src/components/ActivityTimeline.tsx
@@ -32,8 +32,8 @@ import {
       const now = new Date();
       const diffMs = now.getTime() - date.getTime();
 
-      // Handle just now case
-      if (diffMs < 60000) {
+      // Show "Just now" for actions within the last 2 minutes
+      if (diffMs < 120000) {
         return "Just now";
       }
 


### PR DESCRIPTION
Extended the duration for which 'Just now' is displayed for recent actions from 1 minute to 2 minutes in the `ActivityTimeline` component.

This change provides a more natural and user-friendly experience when viewing very recent activity. The surrounding logic for minutes, hours, etc., remains consistent.